### PR TITLE
Removing requirement for OpenSSL gem

### DIFF
--- a/easyrsa.gemspec
+++ b/easyrsa.gemspec
@@ -23,7 +23,6 @@ Gem::Specification.new do |s|
   s.executables   = s.files.grep(%r{^bin/}) { |f| File.basename(f) }
   s.test_files    = s.files.grep(%r{^(test|spec|features)/})
 
-  s.add_dependency 'openssl'
   s.add_dependency 'paint'
   s.add_dependency 'methadone'
 


### PR DESCRIPTION
There is no OpenSSL gem, it's built into MRI. For e.g. JRuby it would be an external dependency, but it's not called `openssl` even in that case.