### PR TITLE
Adding support for optional ST, name

### DIFF
--- a/lib/easyrsa.rb
+++ b/lib/easyrsa.rb
@@ -33,10 +33,16 @@ module EasyRSA
 
 # Helper for issuer details
   def gen_issuer
-    OpenSSL::X509::Name.parse("/C=#{EasyRSA::Config.country}/" \
-      "L=#{EasyRSA::Config.city}/O=#{EasyRSA::Config.company}/OU=#{EasyRSA::Config.orgunit}/" \
-      "CN=#{EasyRSA::Config.server}/" \
-      "emailAddress=#{EasyRSA::Config.email}")
+    name = "/C=#{EasyRSA::Config.country}"
+    name += "/ST=#{EasyRSA::Config.state}" unless !EasyRSA::Config.state || EasyRSA::Config.state.empty?
+    name += "/L=#{EasyRSA::Config.city}"
+    name += "/O=#{EasyRSA::Config.company}"
+    name += "/OU=#{EasyRSA::Config.orgunit}"
+    name += "/CN=#{EasyRSA::Config.server}"
+    name += "/name=#{EasyRSA::Config.name}" unless !EasyRSA::Config.name || EasyRSA::Config.name.empty?
+    name += "/emailAddress=#{EasyRSA::Config.email}"
+
+    OpenSSL::X509::Name.parse(name)
   end
 
 # Helper for generating serials

--- a/lib/easyrsa/ca.rb
+++ b/lib/easyrsa/ca.rb
@@ -69,10 +69,17 @@ module EasyRSA
 
     # Cert issuer details
       def gen_issuer
-        @ca_cert.issuer = OpenSSL::X509::Name.parse("/C=#{EasyRSA::Config.country}/" \
-          "L=#{EasyRSA::Config.city}/O=#{EasyRSA::Config.company}/OU=#{EasyRSA::Config.orgunit}/" \
-          "CN=#{EasyRSA::Config.server}/name=#{EasyRSA::Config.orgunit}/" \
-          "emailAddress=#{EasyRSA::Config.email}")
+        name = "/C=#{EasyRSA::Config.country}"
+        name += "/ST=#{EasyRSA::Config.state}" unless !EasyRSA::Config.state || EasyRSA::Config.state.empty?
+        name += "/L=#{EasyRSA::Config.city}"
+        name += "/O=#{EasyRSA::Config.company}"
+        name += "/OU=#{EasyRSA::Config.orgunit}"
+        name += "/CN=#{EasyRSA::Config.server}"
+        name += "/name=#{EasyRSA::Config.name}" unless !EasyRSA::Config.name || EasyRSA::Config.name.empty?
+        name += "/name=#{EasyRSA::Config.orgunit}" if !EasyRSA::Config.name || EasyRSA::Config.name.empty?
+        name += "/emailAddress=#{EasyRSA::Config.email}"
+
+        @ca_cert.issuer = OpenSSL::X509::Name.parse(name)
       end
 
     # Add Extensions needed

--- a/lib/easyrsa/certificate.rb
+++ b/lib/easyrsa/certificate.rb
@@ -103,9 +103,16 @@ module EasyRSA
 
       # Cert subject for End-User
       def gen_subject
-        @cert.subject = OpenSSL::X509::Name.parse("/C=#{EasyRSA::Config.country}/" \
-          "L=#{EasyRSA::Config.city}/O=#{EasyRSA::Config.company}/OU=#{EasyRSA::Config.orgunit}/CN=#{@id}/" \
-          "emailAddress=#{@email}")
+        subject_name = "/C=#{EasyRSA::Config.country}"
+        subject_name += "/ST=#{EasyRSA::Config.state}" unless !EasyRSA::Config.state || EasyRSA::Config.state.empty?
+        subject_name += "/L=#{EasyRSA::Config.city}"
+        subject_name += "/O=#{EasyRSA::Config.company}"
+        subject_name += "/OU=#{EasyRSA::Config.orgunit}"
+        subject_name += "/CN=#{@id}"
+        subject_name += "/name=#{EasyRSA::Config.name}" unless !EasyRSA::Config.name || EasyRSA::Config.name.empty?
+        subject_name += "/emailAddress=#{@email}"
+
+        @cert.subject = OpenSSL::X509::Name.parse(subject_name)
       end
 
       def add_extensions

--- a/lib/easyrsa/config.rb
+++ b/lib/easyrsa/config.rb
@@ -5,7 +5,7 @@ module EasyRSA
     
     extend self
 
-    attr_accessor :email, :server, :country, :city, :company, :orgunit
+    attr_accessor :email, :server, :country, :city, :company, :orgunit, :name, :state
 
     # Configure easyrsa from a hash. This is usually called after parsing a
     # yaml config file such as easyrsa.yaml.


### PR DESCRIPTION
This PR adds optional support for X.509 ST (state) and name, which are not required for a valid certificate but are necessary to properly name your CA's cert when you sign a client certificate. I was unable to generate valid OpenVPN client certs using our existing CA cert + key without these changes.