### PR TITLE
Dynamically setting gemspec date

### DIFF
--- a/easyrsa.gemspec
+++ b/easyrsa.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new do |s|
 
   s.name        = 'easyrsa'
   s.version     = EasyRSA::VERSION
-  s.date        = '2015-04-29'
+  s.date        = Time.now.to_s.split(' ').first
   s.summary     = 'EasyRSA interface for generating OpenVPN certificates'
   s.description = 'Easily generate OpenVPN certificates without needing the easyrsa packaged scripts'
   s.authors     = ['Mike Mackintosh']


### PR DESCRIPTION
Not sure if you want it set dynamically, but the gemspec still had a hardcoded date from October. Apparently rubygems.org uses this value from the gemspec when it displays version information, as the last few pushes all have a date of 27 April.
